### PR TITLE
Add eslint promise plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,6 +1516,11 @@
         "prettier-linter-helpers": "^1.0.0"
       }
     },
+    "eslint-plugin-promise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
+      "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng=="
+    },
     "eslint-plugin-react": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "author": "Musement",
   "contributors": [
     "Przemysław Fałowski <przemyslaw.falowski@musement.com>",
-    "Marco Ziliani <marco.ziliani@musement.com>"
+    "Marco Ziliani <marco.ziliani@musement.com>",
+    "Aurélien Lair <aurelien.lair@musement.com>"
   ],
   "main": "lib/index.js",
   "repository": {
@@ -26,6 +27,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "~4.17.0",
     "@typescript-eslint/parser": "~4.17.0",
+    "eslint-plugin-promise": "5.1.0",
     "eslint-config-prettier": "~7.2.0",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-nuxt": "~2.0.0",


### PR DESCRIPTION
**WHAT**
Add ESlint promise [plugin](https://www.npmjs.com/package/eslint-plugin-promise)

**WHY**
because it can be useful to have it but most importantly it can bring added value by reinforcing code quality when using promises

**REMARKS**
eslint-plugin-promise@5.1.0 requires a peer of eslint@^7.0.0 so it's fine with what is defined in the peer dependencies